### PR TITLE
#8 회원가입 페이지(상세정보/비밀번호설정) 개발 완료 : signupPage2

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import SignupPage1 from './pages/signupPage1';
+import SignupPage2 from './pages/signupPage2';
 
 function App() {
   return (
@@ -7,6 +8,7 @@ function App() {
       <BrowserRouter>
         <Routes>
           <Route path="/signupPage1" element={<SignupPage1 />} />
+          <Route path="/signupPage2" element={<SignupPage2 />} />
         </Routes>
       </BrowserRouter>
     </div>

--- a/src/pages/signupPage2.jsx
+++ b/src/pages/signupPage2.jsx
@@ -119,24 +119,48 @@ const MICRO_DEGREE = [
 function SignupPage2() {
     const [additionalMajorType, setAdditionalMajorType] = useState('');
     const [additionalMajor, setAdditionalMajor] = useState('');
-    const [password, setPassword] =useState('');
+    const [password, setPassword] = useState('');
+    const [passwordCheck, setPasswordCheck] = useState('');
+    const [error, setError] = useState('');
+    const [checkError, setCheckError] = useState('');
 
-    const noneSelectMajor = () => {
-        if (additionalMajorType !== '') {
-            if(additionalMajor === '') {
-                return true
-            } else {
-                return false
-            }
+    const passwordFormat = (e) => {
+        const regex = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!#^%*?&])[a-zA-Z\d@$!#^%*?&]{8,20}$/;
+        const input = e.target.value;
+        setPassword(input)
+        if (input ===  ''){
+            setError('비밀번호 필수 입력');
         } else {
-            return false
+            if (regex.test(input)){
+                setError('');
+            } else {
+                setError('영문 대/소문자, 숫자, 특수문자를 포함하여 8~20자 입력해주세요.');
+            }
         };
     };
-    const passwordInput = () => {
-
+    const passwordCorrect = (e) => {
+        const input = e.target.value;
+        setPasswordCheck(input);
+        if (password !== '') {
+            if (password === input) {
+                setCheckError('');
+            } else {
+                setCheckError('비밀번호가 일치하지 않습니다.');
+            };
+        } else {
+            setError('비밀번호 필수 입력');
+        };
     };
-    const passwordFormat = () => {
-        const format = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!#^%*?&])[A-Za-z\d@$!#^%*?&]{8,20}$/;
+    const finalCheck = () => {
+        if (password !== '' && passwordCheck !== '' && error === '' && checkError === '') {
+            if (additionalMajorType === '' || (additionalMajorType !== '' && additionalMajor !== '')) {
+                return false
+            } else {
+                return true
+            }
+        } else {
+            return true
+        };
     };
 
     return (
@@ -181,13 +205,19 @@ function SignupPage2() {
                                 <option value={item.value}>{item.label}</option>
                             )) }
                         </select>
-                        <label className={css(styles.infoLable)}>비밀번호 설정<span className={css(styles.essential)}> *</span></label>
-                        <input className={css(styles.additionalInfo)} type="password" placeholder="영문 대/소문자, 숫자, 특수문자 포함 (8~20자)"></input>
-                        <label className={css(styles.infoLable)}>비밀번호 확인<span className={css(styles.essential)}> *</span></label>
-                        <input className={css(styles.additionalInfo)} type="password" placeholder="영문 대/소문자, 숫자, 특수문자 포함 (8~20자)"></input>
+                        <div className={css(styles.pwLabelSpace)}>
+                            <label className={css(styles.infoLable)}>비밀번호 설정<span className={css(styles.essential)}> *</span></label>
+                            { error ? <span className={css(styles.errorMessage)}>{error}</span> : null }
+                        </div>
+                        <input className={css(error ? styles.ErrorAdditionalInfo : styles.additionalInfo)} type="password" onBlur={passwordFormat} placeholder="영문 대/소문자, 숫자, 특수문자 포함 (8~20자)"></input>
+                        <div className={css(styles.pwLabelSpace)}>
+                            <label className={css(styles.infoLable)}>비밀번호 확인<span className={css(styles.essential)}> *</span></label>
+                            { checkError ? <span className={css(styles.errorMessage)}>{checkError}</span> : null }
+                        </div>
+                        <input className={css(checkError ? styles.ErrorAdditionalInfo : styles.additionalInfo)} type="password" onChange={passwordCorrect} placeholder="영문 대/소문자, 숫자, 특수문자 포함 (8~20자)"></input>
                     </div>
                 </div>
-                <button className={css(styles.signUpButton)} disabled={noneSelectMajor()}>가입하기</button>
+                <button className={css(styles.signUpButton)} disabled={finalCheck()}>가입하기</button>
             </div>
             <Footer />
         </>
@@ -288,9 +318,23 @@ const styles = StyleSheet.create({
             outline: '1px solid #2B2A28',
         },
     },
+    pwLabelSpace: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        width: '100%',
+        alignItems: 'center',
+    },
     essential: {
-        color: 'red',
+        color: '#FF4921',
         fontSize: '14px'
+    },
+    errorMessage: {
+        color: '#FF4921',
+        fontSize: '12px',
+        fontFamily: 'Lato',
+        fontWeight: '600',
+        margin: '0 0 6px auto',
+
     },
     additionalInfo: {
         marginBottom: '30px',
@@ -306,6 +350,22 @@ const styles = StyleSheet.create({
         ':focus': {
             color: '#2B2A28',
             outline: '1px solid #2B2A28',
+        },
+    },
+    ErrorAdditionalInfo: {
+        marginBottom: '30px',
+        padding: '0 0 0 15px',
+        width: '410px',
+        height: '46px',
+        border: '1.5px solid #FF4921',
+        borderRadius: '6px',
+        fontFamily: 'Lato',
+        fontSize: '16px',
+        fontWeight: '500',
+        color: '#7A828A',
+        ':focus': {
+            color: '#2B2A28',
+            outline: '0.5px solid #FF4921',
         },
     },
     signUpButton: {

--- a/src/pages/signupPage2.jsx
+++ b/src/pages/signupPage2.jsx
@@ -1,0 +1,181 @@
+import { StyleSheet, css } from 'aphrodite';
+import Header from '../components/header';
+import Template from '../components/template';
+import Footer from '../components/footer';
+
+function SignupPage2() {
+    return (
+        <>
+            <Header />
+            <Template title="회원가입" subtitle="졸업요건 검사 서비스 이용을 위해 약관 동의와 학생 인증 절차가 필요합니다."/>
+            <div className={css(styles.container)}>
+                <div className={css(styles.defaultInfoArea)}>
+                    <span className={css(styles.containerTitle)}>기본 정보 확인</span>
+                    <div className={css(styles.infoContainer)}>
+                        <label className={css(styles.infoLable)}>이름</label>
+                        <input className={css(styles.defaultInfo)} disabled="true" placeholder="홍길동"></input>
+                        <label className={css(styles.infoLable)}>학과</label>
+                        <input className={css(styles.defaultInfo)} disabled="true" placeholder="소프트웨어학과"></input>
+                        <label className={css(styles.infoLable)}>학번</label>
+                        <input className={css(styles.defaultInfo)} disabled="true" placeholder="20240000"></input>
+                    </div>
+                </div>
+                <div className={css(styles.additionalInfoArea)}>
+                    <span className={css(styles.containerTitle)}>추가 정보 설정</span>
+                    <div className={css(styles.infoContainer)}>
+                        <label className={css(styles.infoLable)}>복수/부/연계 전공</label>
+                        <select className={css(styles.majorStatus)}>
+                            <option value="">해당 없음</option>
+                            <option value="double">복수전공</option>
+                            <option value="minor">부전공</option>
+                            <option value="linked">연계전공</option>
+                        </select>
+                        <select className={css(styles.majorSelect)}>
+                            <option></option>
+                        </select>
+                        <label className={css(styles.infoLable)}>소단위전공</label>
+                        <select className={css(styles.majorSelect)}>
+                            <option value="">해당 없음</option>
+                        </select>
+                        <label className={css(styles.infoLable)}>비밀번호 설정</label>
+                        <input className={css(styles.additionalInfo)} type="password" placeholder="영문 대/소문자, 숫자, 특수문자 포함 (8~20자)"></input>
+                        <label className={css(styles.infoLable)}>비밀번호 확인</label>
+                        <input className={css(styles.additionalInfo)} type="password" placeholder="영문 대/소문자, 숫자, 특수문자 포함 (8~20자)"></input>
+                    </div>
+                </div>
+                <button className={css(styles.signUpButton)}>가입하기</button>
+            </div>
+            <Footer />
+        </>
+    )
+
+};
+
+const styles = StyleSheet.create({
+    container: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        margin: '60px 0 0 0',
+        backgroundColor: '#FFFEFB',
+        fontFamily: 'Lato',
+        gap: '65px',
+    },
+    defaultInfoArea: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        width: '424px',
+    },
+    containerTitle: {
+        fontFamily: 'Lato',
+        fontWeight: '600',
+        fontSize: '18px',
+        marginBottom: '25px',
+    },
+    infoContainer: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        width: '424px',
+    },
+    infoLable: {
+        fontFamily: 'Lato',
+        fontWeight: '600',
+        fontSize: '14px',
+        marginBottom: '8px',
+    },
+    defaultInfo: {
+        marginBottom: '30px',
+        padding: '0 0 0 15px',
+        width: '410px',
+        height: '46px',
+        border: '1px solid #CACACA',
+        borderRadius: '6px',
+        fontFamily: 'Lato',
+        fontSize: '16px',
+        fontWeight: '500',
+        color: '#7A828A',
+        backgroundColor: '#F6F6F6'
+    },
+    additionalInfoArea: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        width: '424px',
+    },
+    majorStatus: {
+        marginBottom: '10px',
+        padding: '0 0 0 15px',
+        width: '425px',
+        height: '46px',
+        border: '1px solid #CACACA',
+        borderRadius: '6px',
+        fontFamily: 'Lato',
+        fontSize: '16px',
+        fontWeight: '500',
+        color: '#7A828A',
+        appearance: 'none',
+        backgroundImage: `url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='15' height='15' viewBox='0 0 24 24' fill='none' stroke='%237A828A' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e")`,
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'right 10px center',
+        ':focus':{
+            color: '#2B2A28',
+            outline: '1px solid #2B2A28',
+        },
+    },
+    majorSelect: {
+        marginBottom: '30px',
+        padding: '0 0 0 15px',
+        width: '425px',
+        height: '46px',
+        border: '1px solid #CACACA',
+        borderRadius: '6px',
+        fontFamily: 'Lato',
+        fontSize: '16px',
+        fontWeight: '500',
+        color: '#7A828A',
+        appearance: 'none',
+        backgroundImage: `url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='15' height='15' viewBox='0 0 24 24' fill='none' stroke='%237A828A' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e")`,
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'right 10px center',
+        ':focus':{
+            color: '#2B2A28',
+            outline: '1px solid #2B2A28',
+        },
+    },
+    additionalInfo: {
+        marginBottom: '30px',
+        padding: '0 0 0 15px',
+        width: '410px',
+        height: '46px',
+        border: '1px solid #CACACA',
+        borderRadius: '6px',
+        fontFamily: 'Lato',
+        fontSize: '16px',
+        fontWeight: '500',
+        color: '#7A828A',
+        ':focus': {
+            color: '#2B2A28',
+            outline: '1px solid #2B2A28',
+        },
+    },
+    signUpButton: {
+        margin: '-30px 0 130px 0',
+        width: '117px',
+        height: '40px',
+        border: '0px',
+        borderRadius: '10px',
+        fontFamily: 'Lato',
+        fontWeight: '700',
+        fontSize: '17px',
+        color: '#FFFEFB',
+        backgroundColor: '#2B2A28',
+        ':active': {
+            backgroundColor: '#595650',
+            color: '#FFFEFB',
+        },
+    },
+});
+
+export default SignupPage2;

--- a/src/pages/signupPage2.jsx
+++ b/src/pages/signupPage2.jsx
@@ -1,9 +1,144 @@
+import { useState } from 'react';
 import { StyleSheet, css } from 'aphrodite';
 import Header from '../components/header';
 import Template from '../components/template';
 import Footer from '../components/footer';
 
+const MAJOR = [
+    { value: '030501*', label: '의예과' },
+    { value: '030502*', label: '간호학과' },
+    { value: '030503*', label: '의학과' },
+    { value: '030701*', label: '국어교육과' },
+    { value: '030702*', label: '지리교육과' },
+    { value: '030704*', label: '수학교육과' },
+    { value: '030705*', label: '체육교육과' },
+    { value: '030707*', label: '컴퓨터교육과' },
+    { value: '030709*', label: '영어교육과' },
+    { value: '030710*', label: '역사교육과' },
+    { value: '030790*', label: '통합사회' },
+    { value: '031103*', label: '관광경영학과' },
+    { value: '031108*', label: '스포츠건강관리학과' },
+    { value: '031110*', label: '호텔경영학과' },
+    { value: '031112*', label: '스포츠레저학과' },
+    { value: '031163*', label: '스포츠지도학과' },
+    { value: '031191*', label: '스포테인먼트전공(F)' },
+    { value: '031193*', label: '조리외식경영학과' },
+    { value: '03120202', label: '건축학부-건축공학' },
+    { value: '03120203', label: '건축학부-건축학' },
+    { value: '031214*', label: '토목공학과' },
+    { value: '031224*', label: '전자공학과' },
+    { value: '031230*', label: '소프트웨어학과' },
+    { value: '031241*', label: '기술창업학과' },
+    { value: '031295*', label: 'AI융합전공(C)' },
+    { value: '031297*', label: 'AI융합전공(F)' },
+    { value: '031298*', label: '항만물류시스템전공' },
+    { value: '031299*', label: '반도체융합전공' },
+    { value: '032302*', label: '사회복지학과' },
+    { value: '032303*', label: '경영학과' },
+    { value: '032305*', label: '광고홍보학과' },
+    { value: '03232002', label: '경찰행정학부-경찰행정학' },
+    { value: '03232003', label: '경찰행정학부-해양경찰' },
+    { value: '032321*', label: '행정학과' },
+    { value: '032391*', label: '스타트업콘텐츠마케팅전공(F)-스타트업콘텐츠마케팅' },
+    { value: '032401*', label: '의료공학과' },
+    { value: '032402*', label: '의료IT학과' },
+    { value: '032403*', label: '의생명과학과' },
+    { value: '032405*', label: '의료경영학과' },
+    { value: '032408*', label: '바이오융합공학과' },
+    { value: '032415*', label: '안경광학과' },
+    { value: '032490*', label: '정밀의료융합전공' },
+    { value: '032491*', label: '디지털헬스케어융합전공' },
+    { value: '032492*', label: '스마트수소에너지융합전공' },
+    { value: '032501*', label: '항공운항서비스학과' },
+    { value: '032506*', label: '항공교통물류학과' },
+    { value: '032510*', label: '항공운항학과' },
+    { value: '032515*', label: '무인항공학과' },
+    { value: '032520*', label: '항공정비학과' },
+    { value: '032591*', label: '항공설계전공(F-C)' },
+    { value: '03260103', label: '공연예술학부-실용음악' },
+    { value: '03260104', label: '공연예술학부-연기예술' },
+    { value: '032603*', label: '뷰티디자인학과-뷰티디자인' },
+    { value: '032608*', label: '콘텐츠제작학과' },
+    { value: '032609*', label: 'CG디자인학과' },
+    { value: '032702*', label: '치매전문재활학과' },
+    { value: '032703*', label: '산림치유학과' },
+    { value: '032705*', label: '언어재활학과' },
+    { value: '032708*', label: '복지상담학과' },
+    { value: '032709*', label: '스마트통합치유학과' },
+    { value: '032710*', label: '해양치유레저학과' },
+    { value: '032801*', label: '임상병리학과' },
+    { value: '032802*', label: '치위생학과' },
+    { value: '03290112', label: '트리니티자유-반려동물학' },
+    { value: '03290113', label: '트리니티자유-군사학' },
+    { value: '03300101', label: '트리니티융합-의료경영학' },
+    { value: '03300102', label: '트리니티융합-바이오메디컬' },
+    { value: '03300103', label: '트리니티융합-디지털헬스케어' },
+    { value: '03300104', label: '트리니티융합-행정학' },
+    { value: '03300105', label: '트리니티융합-사회복지학' },
+    { value: '03300106', label: '트리니티융합-경영학' },
+    { value: '03300107', label: '트리니티융합-광고홍보학' },
+    { value: '03300108', label: '트리니티융합-호텔경영학' },
+    { value: '03300109', label: '트리니티융합-조리외식경영학' },
+    { value: '03300110', label: '트리니티융합-스포츠레저학' },
+    { value: '03300111', label: '트리니티융합-스포츠건강관리학' },
+    { value: '03300112', label: '트리니티융합-스포츠지도학' },
+    { value: '03300113', label: '트리니티융합-항공교통물류' },
+    { value: '03300114', label: '트리니티융합-항공운항' },
+    { value: '03300115', label: '트리니티융합-항공정비학' },
+    { value: '03300116', label: '트리니티융합-스마트항만공학' },
+    { value: '03300117', label: '트리니티융합-건축학' },
+    { value: '03300118', label: '트리니티융합-건축공학' },
+    { value: '03300119', label: '트리니티융합-실용음악' },
+    { value: '03300120', label: '트리니티융합-콘텐츠제작' },
+    { value: '03300121', label: '트리니티융합-CG디자인' },
+    { value: '03301001', label: '경찰학부-경찰행정학' },
+    { value: '03301002', label: '경찰학부-해양경찰' },
+    { value: '033020*', label: '자율전공학부' },
+];
+const MICRO_DEGREE = [
+    { value: '110', label: '스마트시티 마이크로디그리' },
+    { value: '120', label: '재난안전소방 마이크로디그리' },
+    { value: '130', label: '지속가능발전 마이크로디그리' },
+    { value: '140', label: 'AI리터러시 마이크로디그리' },
+    { value: '141', label: 'AI기반환경디자인홍보 마이크로디그리' },
+    { value: '150', label: '스마트기술창업 마이크로디그리' },
+    { value: '160', label: '스포츠경영관리분석 마이크로디그리' },
+    { value: '170', label: '디지털스포츠헬스케어 마이크로디그리' },
+    { value: '180', label: '디지털영상콘텐츠 마이크로디그리' },
+    { value: '190', label: '반도체공정및장비 마이크로디그리' },
+    { value: '200', label: '의료AI시스템 마이크로디그리' },
+    { value: '210', label: '다문화와한국어교육 마이크로디그리' },
+    { value: '220', label: '융합형사이버수사 마이크로디그리' },
+    { value: '230', label: '웰니스치유농업 마이크로디그리' },
+    { value: '240', label: '데이터리터러시 마이크로디그리' },
+    { value: '250', label: '미래모빌리티 마이크로디그리' },
+    { value: '260', label: '의료데이터분석&시각화 마이크로디그리' },
+    { value: '270', label: '스마트푸드테크와IT 마이크로디그리' },
+];
+
 function SignupPage2() {
+    const [additionalMajorType, setAdditionalMajorType] = useState('');
+    const [additionalMajor, setAdditionalMajor] = useState('');
+    const [password, setPassword] =useState('');
+
+    const noneSelectMajor = () => {
+        if (additionalMajorType !== '') {
+            if(additionalMajor === '') {
+                return true
+            } else {
+                return false
+            }
+        } else {
+            return false
+        };
+    };
+    const passwordInput = () => {
+
+    };
+    const passwordFormat = () => {
+        const format = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!#^%*?&])[A-Za-z\d@$!#^%*?&]{8,20}$/;
+    };
+
     return (
         <>
             <Header />
@@ -13,37 +148,46 @@ function SignupPage2() {
                     <span className={css(styles.containerTitle)}>기본 정보 확인</span>
                     <div className={css(styles.infoContainer)}>
                         <label className={css(styles.infoLable)}>이름</label>
-                        <input className={css(styles.defaultInfo)} disabled="true" placeholder="홍길동"></input>
+                        <input className={css(styles.defaultInfo)} disabled="true" value="홍길동"></input>
                         <label className={css(styles.infoLable)}>학과</label>
-                        <input className={css(styles.defaultInfo)} disabled="true" placeholder="소프트웨어학과"></input>
+                        <input className={css(styles.defaultInfo)} disabled="true" value="소프트웨어학과"></input>
                         <label className={css(styles.infoLable)}>학번</label>
-                        <input className={css(styles.defaultInfo)} disabled="true" placeholder="20240000"></input>
+                        <input className={css(styles.defaultInfo)} disabled="true" value="20240000"></input>
                     </div>
                 </div>
                 <div className={css(styles.additionalInfoArea)}>
                     <span className={css(styles.containerTitle)}>추가 정보 설정</span>
                     <div className={css(styles.infoContainer)}>
                         <label className={css(styles.infoLable)}>복수/부/연계 전공</label>
-                        <select className={css(styles.majorStatus)}>
+                        <select className={css(styles.majorStatus)} onChange={(e) => setAdditionalMajorType(e.target.value)}>
                             <option value="">해당 없음</option>
                             <option value="double">복수전공</option>
                             <option value="minor">부전공</option>
                             <option value="linked">연계전공</option>
                         </select>
-                        <select className={css(styles.majorSelect)}>
-                            <option></option>
+                        <select className={css(styles.majorSelect)} onChange={(e) => setAdditionalMajor(e.target.value)}>
+                            { additionalMajorType ? (
+                                <>
+                                    <option value="">선택</option>
+                                    { MAJOR.map((item) => (
+                                        <option value={item.value}>{item.label}</option>
+                                    )) }
+                                </> ) : ( <option value=""></option> ) }
                         </select>
                         <label className={css(styles.infoLable)}>소단위전공</label>
                         <select className={css(styles.majorSelect)}>
                             <option value="">해당 없음</option>
+                            { MICRO_DEGREE.map((item) => (
+                                <option value={item.value}>{item.label}</option>
+                            )) }
                         </select>
-                        <label className={css(styles.infoLable)}>비밀번호 설정</label>
+                        <label className={css(styles.infoLable)}>비밀번호 설정<span className={css(styles.essential)}> *</span></label>
                         <input className={css(styles.additionalInfo)} type="password" placeholder="영문 대/소문자, 숫자, 특수문자 포함 (8~20자)"></input>
-                        <label className={css(styles.infoLable)}>비밀번호 확인</label>
+                        <label className={css(styles.infoLable)}>비밀번호 확인<span className={css(styles.essential)}> *</span></label>
                         <input className={css(styles.additionalInfo)} type="password" placeholder="영문 대/소문자, 숫자, 특수문자 포함 (8~20자)"></input>
                     </div>
                 </div>
-                <button className={css(styles.signUpButton)}>가입하기</button>
+                <button className={css(styles.signUpButton)} disabled={noneSelectMajor()}>가입하기</button>
             </div>
             <Footer />
         </>
@@ -144,6 +288,10 @@ const styles = StyleSheet.create({
             outline: '1px solid #2B2A28',
         },
     },
+    essential: {
+        color: 'red',
+        fontSize: '14px'
+    },
     additionalInfo: {
         marginBottom: '30px',
         padding: '0 0 0 15px',
@@ -171,9 +319,13 @@ const styles = StyleSheet.create({
         fontSize: '17px',
         color: '#FFFEFB',
         backgroundColor: '#2B2A28',
-        ':active': {
+        ':active:not(:disabled)': {
             backgroundColor: '#595650',
             color: '#FFFEFB',
+        },
+        ':disabled':{
+            color: '#FFFEFB',
+            backgroundColor: '#CACACA',
         },
     },
 });

--- a/src/pages/signupPage2.jsx
+++ b/src/pages/signupPage2.jsx
@@ -379,6 +379,9 @@ const styles = StyleSheet.create({
         fontSize: '17px',
         color: '#FFFEFB',
         backgroundColor: '#2B2A28',
+        ':hover:not(:disabled)': {
+            cursor: 'pointer',
+        },
         ':active:not(:disabled)': {
             backgroundColor: '#595650',
             color: '#FFFEFB',


### PR DESCRIPTION
#8 
회원가입 페이지(상세정보/비밀번호설정) 개발 완료했습니다.

**학생 기본 정보**는 하드코딩으로 개발했고 추후 학생인증 BE 개발 후 연동 시 반영할 예정입니다.

**비밀번호 형식, 재입력 유효성 검사**는 input 상자 테두리 색 변경 및 우상단에 오류 메시지 추가하여 구현했습니다.

추가 전공 여부 (복수전공/부전공/연계전공) 만 설정하고 **학과 미선택 시** 가입하기 버튼 비활성화하여 학과 미선택 유효성 검사 또한 개발했습니다.



## 주요 개발 사항
- 레이아웃 개발
- 복수/부/연계전공 리스트 입력 
(CKU 개설 강좌조회 학과 선택 ∩ 에브리타임 24-2 시간표 설정 학과 선택)

- 소단위전공 리스트 입력 
(25년도 신설 MD 반영)

- 비밀번호 형식 유효성 검사 
(비밀번호 미 입력 & 비밀번호 정규 표현식 형식 & 비밀번호 일치 여부)
<img width="460" alt="스크린샷 2025-01-03 21 22 27" src="https://github.com/user-attachments/assets/8c09b382-d734-4623-a9d5-262be8d854ec" />
<img width="462" alt="스크린샷 2025-01-03 21 22 11" src="https://github.com/user-attachments/assets/5a622cf1-8c5f-4b77-a79f-c076834efeb2" />
<img width="475" alt="스크린샷 2025-01-03 21 23 51" src="https://github.com/user-attachments/assets/00306b44-cf7e-4bd7-8337-27ac9f0975e5" />



- 가입하기 버튼 유효성 검사 
(비밀번호 형식 & 추가 전공 선택)
<img width="458" alt="스크린샷 2025-01-03 21 27 06" src="https://github.com/user-attachments/assets/86692e4a-53e5-4df5-9a0c-4eeb0b5aa2fc" />


## 추후 변경 필요 사항
- 학생 인증 학생 기본 정보 크롤링 반영
- 가입 정보 DB 연동
- (필요 시) 전공, 소단위 전공 상수 전역 관리 
- 추가 전공, 주 전공과 겹치지 않도록 예외 처리 추가