### PR TITLE
feat 채널톡 SDK 설치 및 파이프라인 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@ant-design/icons": "^5.5.2",
+    "@channel.io/channel-web-sdk-loader": "^2.0.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^13.2.1",

--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import ManageGraduPage from './pages/manageGraduPage';
 import FeatureModal from './components/featureModal';
 import GraduTestPage from './pages/graduTestPage';
 import OneClickTestPage from './pages/oneClickTestPage';
+import ChannelTalk from './utils/channelTalk';
 
 function App() {
     const [modalState, setModalState] = useState(false);
@@ -39,6 +40,7 @@ function App() {
     };
 
     useEffect(() => {
+        ChannelTalk();
         if (new Date().getTime() > localStorage.getItem('expire')) {
             localStorage.clear();
         };

--- a/src/utils/channelTalk.js
+++ b/src/utils/channelTalk.js
@@ -1,0 +1,10 @@
+import * as ChannelService from '@channel.io/channel-web-sdk-loader';
+
+function ChannelTalk() {
+    ChannelService.loadScript()
+    ChannelService.boot({
+        pluginKey: process.env.REACT_APP_CHANNEL_TALK_PLUGIN_KEY ?? ''
+    });
+}
+
+export default ChannelTalk;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1116,6 +1116,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@channel.io/channel-web-sdk-loader@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@channel.io/channel-web-sdk-loader/-/channel-web-sdk-loader-2.0.0.tgz#d8bc196222a9b8045af6c8418f7693c466db6100"
+  integrity sha512-Z8DDpf2lAaYr/3aAnwQtxg0L8MYWgi/hhGV8c5/SLCV6Fx5Gssj7mfyHHrCVC315B0icmLYqZsXBlmbf6cN8Jg==
+
 "@csstools/normalize.css@*":
   version "12.1.1"
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-12.1.1.tgz#f0ad221b7280f3fc814689786fd9ee092776ef8f"


### PR DESCRIPTION
- [ ] 채널톡 channel-web-sdk-loader SDK 설치
ㄴ https://github.com/channel-io/channel-web-sdk-loader?tab=readme-ov-file (채널톡 웹 로더 SDK 깃허브)
- [ ] src/utils/channelTalk.js 모듈화
ㄴ https://developers.channel.io/reference/web-quickstart-kr (채널톡 공식 문서)
- [ ] 플러그인 키 .env 환경변수 설정