### PR TITLE
refactor 전공-전공코드 매핑 방식 변경 + 졸업 기준 미충족 시 학점 차트 컬러 재설정

### DIFF
--- a/src/components/graduChartComponents.jsx
+++ b/src/components/graduChartComponents.jsx
@@ -8,19 +8,32 @@ import success from '../assets/images/success.png';
 Chart.register(ArcElement, Tooltip, Legend);
 
 const GraduChartComponenets = ({ earned, total }) => {
-    var remaining = total - earned;
+    let remaining = total - earned;
     if (remaining < 0) {
         remaining = 0
     };
+
+let colors;
+let hoverColors;
+
+if (localStorage.getItem('lackTotal') === null) {
+    // 부족 영역 없음
+    colors = ["#FF8EA8", "#E0E0E0"];
+    hoverColors = ['#EA7175', '#BDBDBD'];
+} else {
+    // // 부족 영역이 있을 때
+    colors = ["#3D5286", "#E0E0E0"];
+    hoverColors = ["#3D5286", "#BDBDBD"];
+}
+
 
     const data = {
         labels: ["취득 학점", "남은 학점"],
         datasets: [
             {
                 data: [earned, remaining],
-                backgroundColor: remaining > 0 ? ["#3D5286", "#E0E0E0"] : ["#FF8EA8", '#E0E0E0'],
-                hoverBackgroundColor: remaining > 0 ? ["#3D5286", "#BDBDBD"] : ['#EA7175', '#BDBDBD'],
-
+                backgroundColor: colors,
+                hoverBackgroundColor: hoverColors,
                 rotation: 225,
                 circumference: 270,
                 borderRadius: [50, 50, 0, 0],
@@ -46,14 +59,14 @@ const GraduChartComponenets = ({ earned, total }) => {
         <div className={css(styles.container)}>
             <Doughnut data={data} options={options} />
 
-            {earned >= total ?
+            {earned >= total && !localStorage.getItem('lackTotal') ?
                 <>
                     <img src={bouquet} alt="학생" className={css(styles.bouquet)} />
                     <img src={success} alt="졸업학생" className={css(styles.success)} />
                 </>
                 : <img src={graduatedstudent} alt="학생" className={css(styles.studentImg)} />}
             <div className={css(styles.statContainer)}>
-                {earned >= total ?
+                {earned >= total && !localStorage.getItem('lackTotal') ?
                     <span className={css(styles.successEarn)}>{earned}</span>
                     : <span className={css(styles.earn)}>{earned}</span>}
                 <span className={css(styles.standard)}> / {total} 학점</span>

--- a/src/pages/signupPage1.jsx
+++ b/src/pages/signupPage1.jsx
@@ -38,10 +38,10 @@ function SignupPage1() {
                     studentId: studentId,
                     studentPW: studentPW,
                 });
-                if (response.data.student_id && response.data.name && response.data.major) {
-                    const { student_id, name, major } = response.data;
+                if (response.data.student_id && response.data.name && response.data.major && response.data.college) {
+                    const { student_id, name, major, college } = response.data;
                     closeFeatModal();
-                    navigate('/signupPage2', { state: { student_id, name, major } });
+                    navigate('/signupPage2', { state: { student_id, name, major, college } });
                     window.scrollTo(0, 0);
                 } else {
                     const { error } = response.data;
@@ -106,7 +106,7 @@ function SignupPage1() {
                             <b>- 학번 : <b className={css(styles.emphasizeText)}>18 ~ 25학번</b></b><br /><br />
                             3. <b className={css(styles.emphasizeText)}>교직이수자, 편입학 대상자</b>의 졸업검사 기준은 포함되지 않아 검사가 불가능합니다.<br /><br />
                             4. 원활한 검사를 위해 <b className={css(styles.emphasizeText)}>PC환경</b>에서 진행할 것을 권장합니다.<br /><br />
-                            5. 검사 기준은 <b className={css(styles.emphasizeText)}>2025학년도 1학기</b> 교육과정을 기준으로 합니다.<br /><br />
+                            5. 검사 기준은 <b className={css(styles.emphasizeText)}>2025학년도 2학기</b> 교육과정을 기준으로 합니다.<br /><br />
                             6. 졸업요건 기준이 잘못 설정되거나, 오류 발생 시 <a href="https://docs.google.com/forms/d/15ueJU2u7EiEBA8uVJI2hExoQqREngYg23wntCTzBZhM/edit#responses" target="_blank" className={css(styles.feedback)}>하단 폼 링크</a>를 통해 피드백 부탁드립니다.<br /><br />
                         </p>
                         <span className={css(styles.contentTitle)}>개인정보처리방침</span>

--- a/src/pages/signupPage2.jsx
+++ b/src/pages/signupPage2.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from 'react';
+import { useState, useContext, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { StyleSheet, css } from 'aphrodite';
 import { ModalContext } from '../utils/hooks/modalContext';
@@ -513,15 +513,17 @@ function SignupPage2() {
     const [error, setError] = useState('');
     const [checkError, setCheckError] = useState('');
     const [microDegree, setMicroDegree] = useState('');
+    const [majorMap, setMajorMap] = useState([]);
+    const [MDMap, setMDMap] = useState([]);
     const navigate = useNavigate();
     const { modalState, openModal, closeModal } = useContext(ModalContext);
     const location = useLocation();
-    const { student_id, name, major } = location.state;
+    const { student_id, name, major, college } = location.state;
 
     // 추가 전공 선택 (MAJOR)
     const checkMajor = (e) => {
         const input = e.target.value
-        if (input === MAJOR.find(item => item.label === major).value) {
+        if (input === majorMap.find(item => item.major_label === major).major_code) {
             alert('주전공과 동일한 전공은 선택할 수 없습니다.');
             e.target.value = '';
             setAdditionalMajor(e.target.value);
@@ -572,7 +574,7 @@ function SignupPage2() {
         try {
             const response = await axios.post('http://127.0.0.1:8000/user/register_info/', {
                 name: name,
-                major: MAJOR.find(item => item.label === major || item.contents.includes(major))?.value || null,
+                major: majorMap.find(item => item.major_label === major || item.major_label.includes(major))?.major_code || null,
                 student_id: student_id,
                 additionalMajorType: additionalMajorType,
                 additionalMajor: additionalMajor,
@@ -601,6 +603,21 @@ function SignupPage2() {
             };
         };
     };
+    const majorMapping = async () => {
+      const response = await axios.get('http://127.0.0.1:8000/user/major_mapping/');
+      if (response.data) {
+          const { majors, MDs } = response.data;
+          setMajorMap(majors);
+          setMDMap(MDs);
+      } else {
+          alert("학과 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.");
+      };
+  };
+
+  useEffect(() => {
+    majorMapping();
+  }, [])
+
     return (
         <>
             {modalState ?
@@ -634,16 +651,16 @@ function SignupPage2() {
                             {additionalMajorType ? (
                                 <>
                                     <option value="">선택</option>
-                                    {MAJOR.map((item) => (
-                                        <option value={item.value}>{item.label}</option>
+                                    {majorMap.map((item) => (
+                                        <option value={item.major_code} disabled={college !== "사범대학" && (item.college === '사범대학' ||  item.college === '의과대학')}>{item.major_label}</option>
                                     ))}
                                 </>) : (<option value=""></option>)}
                         </select>
                         <label className={css(styles.infoLable)}>소단위전공</label>
                         <select className={css(styles.majorSelect)} onChange={(e) => setMicroDegree(e.target.value)}>
                             <option value="">해당 없음</option>
-                            {MICRO_DEGREE.map((item) => (
-                                <option value={item.value}>{item.label}</option>
+                            {MDMap.map((item) => (
+                                <option value={item.major_code}>{item.major_label}</option>
                             ))}
                         </select>
                         <div className={css(styles.pwLabelSpace)}>


### PR DESCRIPTION
## 개요
1. 일반 단과대학 소속 재학생은 복수전공(교직) 불가
-> 하지만 회원가입 또는 마이페이지 에서 복수전공(교직) 설정이 가능했고,
만일 비사범대 재학생이 복수전공(교직) 선택 시 로그인이 막히는 상황 인지.

2. 졸업 학점은 채웠지만 부족한 영역이 남았을 때(단순히 학점만 채웠을 때) 학점 차트 색을 변경해주어 남은 영역이 있는지 혼란
<img width="1393" height="674" alt="스크린샷 2025-09-20 15 15 26" src="https://github.com/user-attachments/assets/b42c1d23-171e-4975-9fc3-263d3fb42c17" />


## 대처
1. FE signupPage2.jsx에 하드코딩해뒀던 전공 매핑값을 MajorMap, MajorAlias 테이블에 분배하여
데이터를 저장.
회원가입 시 소속대학에 따라 복수/부전공 선택지 제한

2. 부족한 영역까지 이수 완료해야 학점 차트 색 변경
<img width="1222" height="675" alt="스크린샷 2025-10-30 23 58 31" src="https://github.com/user-attachments/assets/ba687c18-23d0-4bc0-ab87-c15ee862c556" />

