### PR TITLE
feat 졸업요건 이수 완료 confetti 효과 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lucide-react": "^0.477.0",
     "prop-types": "^15.8.1",
     "react": "^19.0.0",
+    "react-canvas-confetti": "^2.0.7",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.4.0",

--- a/src/pages/graduTestPage.jsx
+++ b/src/pages/graduTestPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext } from 'react';
+import { useState, useEffect, useContext, useMemo } from 'react';
 import { StyleSheet, css } from 'aphrodite';
 import { useNavigate } from 'react-router-dom';
 import { SUBMAJORTYPE } from '../pages/signupPage2';
@@ -61,7 +61,10 @@ function GraduTestPage() {
     const [trinity, setTrinity] = useState();
     const [majorMap, setMajorMap] = useState([]);
     const [MDMap, setMDMap] = useState([]);
+
+    const [loadingState, setLoadingState] = useState(false);
     const [confetti, setConfetti] = useState(false);
+    const [graduationState, setGraduationState] = useState(false);
 
     const year = parseInt(localStorage.getItem('idToken').substr(0, 4));
     const navigate = useNavigate();
@@ -88,6 +91,7 @@ function GraduTestPage() {
             setLackMajor(lackMajor)
             setLackSubMajor(lackSubMajor)
             { localStorage.setItem('lackSubMajor', lackSubMajor) }
+            setLoadingState(true)
         } else {
             alert('서버와 연결이 불안정합니다. 잠시 후 다시 시도해주세요.');
         };
@@ -183,14 +187,6 @@ function GraduTestPage() {
         };
     };
 
-    const popConfetti = () => {
-        if (restStandard <= (doneMajorRest + doneSubMajorRest + doneGERest + doneMDRest + doneEducationRest + doneRest) && (lackMajor + lackSubMajor + lackEssentialGE + lackChoiceGE + lackMD <= 0)){
-            setTimeout(() => {
-                setConfetti(true);
-            }, 1000);
-        };
-    };
-
     useEffect(() => {
         testing();
         localStorage.setItem('testing', true);
@@ -199,8 +195,23 @@ function GraduTestPage() {
         microDegreeCheck();
         educationCheck();
         majorMapping();
-        popConfetti();
     }, []);
+
+    useEffect(() => {
+        if (!loadingState) return;
+        const successGraduation = (restStandard <= (doneMajorRest + doneSubMajorRest + doneGERest + doneMDRest + doneEducationRest + doneRest)) && (lackMajor + lackSubMajor + lackEssentialGE + lackChoiceGE + lackMD <= 0)
+        setGraduationState(successGraduation)
+    }, [loadingState, restStandard, doneMajorRest, doneSubMajorRest, doneGERest, doneMDRest, doneEducationRest, doneRest, lackMajor, lackSubMajor, lackEssentialGE, lackChoiceGE, lackMD]);
+
+    useEffect(() => {
+        if (graduationState) {
+            setTimeout(() => {
+                setConfetti(true);
+            }, 500);
+        } else {
+            setConfetti(false);
+        };
+    }, [graduationState])
 
     return (
         <>

--- a/src/pages/graduTestPage.jsx
+++ b/src/pages/graduTestPage.jsx
@@ -14,6 +14,7 @@ import sogood from "../assets/images/sogood.png";
 import light from "../assets/images/light.png";
 import magnifyingGlass from "../assets/images/magnifyingGlass.png";
 import axios from 'axios';
+import Realistic from 'react-canvas-confetti/dist/presets/realistic';
 
 function GraduTestPage() {
     const [major, setMajor] = useState();
@@ -60,6 +61,7 @@ function GraduTestPage() {
     const [trinity, setTrinity] = useState();
     const [majorMap, setMajorMap] = useState([]);
     const [MDMap, setMDMap] = useState([]);
+    const [confetti, setConfetti] = useState(false);
 
     const year = parseInt(localStorage.getItem('idToken').substr(0, 4));
     const navigate = useNavigate();
@@ -181,6 +183,14 @@ function GraduTestPage() {
         };
     };
 
+    const popConfetti = () => {
+        if (restStandard <= (doneMajorRest + doneSubMajorRest + doneGERest + doneMDRest + doneEducationRest + doneRest) && (lackMajor + lackSubMajor + lackEssentialGE + lackChoiceGE + lackMD <= 0)){
+            setTimeout(() => {
+                setConfetti(true);
+            }, 1000);
+        };
+    };
+
     useEffect(() => {
         testing();
         localStorage.setItem('testing', true);
@@ -189,10 +199,14 @@ function GraduTestPage() {
         microDegreeCheck();
         educationCheck();
         majorMapping();
+        popConfetti();
     }, []);
 
     return (
         <>
+            {confetti &&
+                <Realistic autorun={{ speed: 0.3, duration: 5 }} />
+            }
             {detailModalState ? 
                 <DetailModal detailModalTitle={
                     <>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1935,6 +1935,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/canvas-confetti@^1.6.4":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz#d1077752e046413c9881fbb2ba34a70ebe3c1773"
+  integrity sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==
+
 "@types/connect-history-api-fallback@^1.3.5":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz#7de71645a103056b48ac3ce07b3520b819c1d5b3"
@@ -3166,6 +3171,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001688:
   version "1.0.30001690"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz#f2d15e3aaf8e18f76b2b8c1481abde063b8104c8"
   integrity sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==
+
+canvas-confetti@^1.9.2:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/canvas-confetti/-/canvas-confetti-1.9.4.tgz#4412a5daa96afd0b4d70ecd66b65ce8db3022b2b"
+  integrity sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"
@@ -7998,6 +8008,14 @@ react-app-polyfill@^3.0.0:
     raf "^3.4.1"
     regenerator-runtime "^0.13.9"
     whatwg-fetch "^3.6.2"
+
+react-canvas-confetti@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/react-canvas-confetti/-/react-canvas-confetti-2.0.7.tgz#0499e7815b50f6a7731fd01729e07c30faa300f3"
+  integrity sha512-DIj44O35TPAwJkUSIZqWdVsgAMHtVf8h7YNmnr3jF3bn5mG+d7Rh9gEcRmdJfYgRzh6K+MAGujwUoIqQyLnMJw==
+  dependencies:
+    "@types/canvas-confetti" "^1.6.4"
+    canvas-confetti "^1.9.2"
 
 react-chartjs-2@^5.3.0:
   version "5.3.0"


### PR DESCRIPTION
## react-canvas-confetti 라이브러리
[react-canvas-confetti](https://github.com/ulitcos/react-canvas-confetti?tab=readme-ov-file#Examples)

설치 커멘드
: `yarn add react-canvas-confetti`

react-canvas-confetti 라이브러리 중 realistic 효과를 적용했습니다.
useEffect(()=> {},[])로 초기 페이지 렌더링 시 효과 일부 노출되는 현상 발생하여,
setTimeout 0.5초 적용 후 렌더링 되도록 useEffect에 추가했습니다.


## 예시
![Adobe Express - 화면 기록 2025-11-09 22 09 02](https://github.com/user-attachments/assets/399e0a7b-3813-4ad7-9fec-02ba7e7f183c)
