### PR TITLE
feat: GA4 웹 분석 연동

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Create .env file
         run: |
           echo "REACT_APP_CHANNEL_TALK_PLUGIN_KEY = ${{ secrets.CHANNEL_TALK_PLUGIN_KEY }}" > .env
+          echo "REACT_APP_GA_MEASUREMENT_ID = G-L9V8KGLRDG" >> .env
 
       - name: Build React app
         run: CI=false yarn build

--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,8 @@ import ManageGraduPage from './pages/manageGraduPage';
 import GraduTestPage from './pages/graduTestPage';
 import OneClickTestPage from './pages/oneClickTestPage';
 import ChannelTalk from './utils/channelTalk';
+import PageTracking from './utils/hooks/usePageTracking';
+import { setUserId } from './utils/ga';
 
 function App() {
     const [modalState, setModalState] = useState(false);
@@ -54,10 +56,16 @@ function App() {
         };
     })
 
+    // 이미 로그인된 상태로 재방문한 경우에도 기기 간 사용자 연결이 되도록 한다.
+    useEffect(() => {
+        setUserId(localStorage.getItem('idToken'));
+    }, []);
+
     return (
         <ModalContext.Provider value={{ modalState, setModalState, featModalState, setFeatModalState, detailModalState, setDetailModalState, subButtonState, setSubButtonState, featButtonState, setFeatButtonState, openModal, closeModal, openFeatModal, closeFeatModal, openDetailModal, closeDetailModal, featCloseButton, setFeatCloseButton, addSubject, setAddSubject }}>
             <div className="App">
                 <BrowserRouter>
+                    <PageTracking />
                     <Routes>
                         <Route path="/signupPage1" element={<SignupPage1 />} />
                         <Route path="/uploadpdf" element={<UploadPdfPage />} />

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -2,6 +2,7 @@ import { useState, useContext } from 'react';
 import { useNavigate } from "react-router-dom";
 import { StyleSheet, css } from 'aphrodite';
 import { ModalContext } from '../utils/hooks/modalContext';
+import { clearUserId } from '../utils/ga';
 import mainLogo from '../assets/images/mainLogo.png';
 
 function Header() {
@@ -11,6 +12,7 @@ function Header() {
     const logOut = () => {
         if (localStorage.getItem('idToken')) {
             localStorage.clear();
+            clearUserId();
             navigate("/loginPage");
         }
     };

--- a/src/components/uploadPdfComponents.jsx
+++ b/src/components/uploadPdfComponents.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { StyleSheet, css } from 'aphrodite';
 import { RiExternalLinkLine } from "react-icons/ri";
 import axios from 'axios';
+import { sendEvent } from '../utils/ga';
 import pdfIcon from '../assets/images/pdfIcon.svg';
 import mockupDevice from '../assets/images/mockupDevice.png';
 import pdfGuide1 from '../assets/images/pdfGuide1.gif';
@@ -71,6 +72,7 @@ function UploadPdfComponents() {
 
             if (imageFiles.length > 0) {
                 setLoading(false);
+                sendEvent('upload_pdf', { status: 'image_file', file_count: imageFiles.length });
                 alert(`PDF 파일 형식이 올바르지 않습니다.\n기이수과목 등록은 PC 환경에서 진행해주세요.\n\n파일명:\n${imageFiles.join('\n')}`);
                 setSelectedFiles([]);
                 setFileNames([]);
@@ -78,6 +80,7 @@ function UploadPdfComponents() {
 
             if (errorFiles.length > 0) {
                 setLoading(false);
+                sendEvent('upload_pdf', { status: 'invalid_format', file_count: errorFiles.length });
                 alert(`PDF 파일 형식이 올바르지 않습니다.\n기이수과목 PDF 파일 저장 시 "인쇄 > PDF로 저장"을 확인하세요.\n\n파일명:\n${errorFiles.join('\n')}`);
                 setSelectedFiles([]);
                 setFileNames([]);
@@ -85,6 +88,7 @@ function UploadPdfComponents() {
 
             if (duplicateFiles.length > 0) {
                 setLoading(false);
+                sendEvent('upload_pdf', { status: 'duplicate', file_count: duplicateFiles.length });
                 alert(`중복된 파일이 포함되어 있습니다:\n기이수과목 관리 화면으로 넘어갑니다.\n\n파일명:\n${duplicateFiles.join('\n')}`);
                 setSelectedFiles([]);
                 setFileNames([]);
@@ -95,6 +99,7 @@ function UploadPdfComponents() {
             if (successFiles.length > 0){
                 setLoading(false);
                 localStorage.setItem('uploadPDF', true);
+                sendEvent('upload_pdf', { status: 'success', file_count: successFiles.length });
                 alert('파일이 성공적으로 업로드되었습니다.');
                 setSelectedFiles([]);
                 setFileNames([]);
@@ -110,6 +115,7 @@ function UploadPdfComponents() {
         } catch (error) {
             setLoading(false);
             console.error('업로드 에러:', error);
+            sendEvent('upload_pdf', { status: 'error', file_count: selectedFiles.length });
             alert(error.response?.data?.message || '파일 업로드 중 오류가 발생했습니다.');
             setSelectedFiles([]);
             setFileNames([]);

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,10 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { initGA } from './utils/ga';
+
+// 첫 page_view보다 gtag 설정이 먼저 큐에 들어가야 하므로 렌더 전에 호출한다.
+initGA();
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/src/pages/doneLecturePage.jsx
+++ b/src/pages/doneLecturePage.jsx
@@ -7,6 +7,7 @@ import Footer from '../components/footer';
 import { DoneSubComponents } from '../components/doneLectureComponents';
 import UploadPdfPageComponents from '../components/uploadPdfComponents';
 import axios from 'axios';
+import { sendEvent } from '../utils/ga';
 import { TiDelete } from "react-icons/ti";
 import { MdAutoMode } from "react-icons/md";
 import { FaArrowRightLong } from "react-icons/fa6";
@@ -196,17 +197,21 @@ function DoneLecturePage() {
                 });
 
                 if (!allResponse.data || allResponse.data.length === 0) {
+                    sendEvent('search_lecture', { search_type: searchCodeSelect.value, search_term: lectureCode, status: 'not_found' });
                     searchCodeSelect.value === "searchCode" ? alert("과목코드를 다시 확인하세요.") : alert("과목명을 다시 확인하세요.")
                 } else if (allResponse.data && allResponse.data.length > 0) {
+                    sendEvent('search_lecture', { search_type: searchCodeSelect.value, search_term: lectureCode, status: 'other_semester' });
                     alert(`20${searchSemesterSelect.label} 내에 존재하지 않는 교과목입니다.\n과목코드를 다시 확인하세요.`);
                 }
 
             } else {
+                sendEvent('search_lecture', { search_type: searchCodeSelect.value, search_term: lectureCode, status: 'found', result_count: response.data.length });
                 setLectureData(response.data);
                 console.log(response.data)
             }
 
         } catch (error) {
+            sendEvent('search_lecture', { search_type: searchCodeSelect.value, search_term: lectureCode, status: 'error' });
             setError('과목 정보를 가져오는데 실패했습니다.');
             alert('과목 정보를 가져오는데 실패했습니다.');
         }
@@ -257,6 +262,7 @@ function DoneLecturePage() {
                 alert("과목 저장에 실패했습니다.");
             }
 
+            sendEvent('save_done_lecture', { subject_count: subjectsToSave.length });
             myLectureUpdate();
 
             //현재 과목 목록을 내 기이수 과목으로 전달했다면 subjectNew 상태 저장(색상 변경을 위함)
@@ -476,7 +482,7 @@ function DoneLecturePage() {
                         <span className={css(styles.secondTitle)}>내 기이수 과목</span>
                         {showTextboxContainer ?
                             null :
-                            <div className={css(styles.simulationToggleContainer)} onClick={() => setShowTextboxContainer(v => !v)}>
+                            <div className={css(styles.simulationToggleContainer)} onClick={() => { sendEvent('open_simulation'); setShowTextboxContainer(v => !v); }}>
                                 <MdAutoMode />
                                 <span>이수 과목 시뮬레이션</span>
                             </div>

--- a/src/pages/graduTestPage.jsx
+++ b/src/pages/graduTestPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext, useMemo } from 'react';
+import { useState, useEffect, useContext, useMemo, useRef } from 'react';
 import { StyleSheet, css } from 'aphrodite';
 import { useNavigate } from 'react-router-dom';
 import { SUBMAJORTYPE } from '../pages/signupPage2';
@@ -14,6 +14,7 @@ import sogood from "../assets/images/sogood.png";
 import light from "../assets/images/light.png";
 import magnifyingGlass from "../assets/images/magnifyingGlass.png";
 import axios from 'axios';
+import { sendEvent } from '../utils/ga';
 import Realistic from 'react-canvas-confetti/dist/presets/realistic';
 
 function GraduTestPage() {
@@ -66,34 +67,44 @@ function GraduTestPage() {
     const [confetti, setConfetti] = useState(false);
     const [graduationState, setGraduationState] = useState(false);
 
+    const [checkDone, setCheckDone] = useState(0);  // 전공/교양/소단위/교직 검사 완료 개수 (GA 결과 집계용)
+    const graduationEventSent = useRef(false);
+
     const year = parseInt(localStorage.getItem('idToken').substr(0, 4));
     const navigate = useNavigate();
     const { detailModalState, setDetailModalState, openDetailModal, closeDetailModal } = useContext(ModalContext);
 
     const testing = async () => {
-        const response = await axios.post('https://finishline-cku.com/graduation/test_major/', {
-            student_id : localStorage.getItem('idToken')
-        });
-        if (response.data) {
-            const { major, subMajorType, doneMajor, doneSubMajor, doneMajorRest, doneSubMajorRest, doneRest, totalStandard, majorStandard, subMajorStandard, essentialGEStandard, choiceGEStandard, lackMajor, lackSubMajor } = response.data;
-            setMajor(major)
-            setSubMajorType(subMajorType)  // subMajorType / doneSubMajor / subMajorStandard
-            setDoneMajor(doneMajor)
-            setDoneSubMajor(doneSubMajor)
-            setDoneMajorRest(doneMajorRest)
-            setDoneSubMajorRest(doneSubMajorRest)
-            setDoneRest(doneRest)
-            setTotalStandard(totalStandard)
-            setMajorStandard(majorStandard)
-            setSubMajorStandard(subMajorStandard)
-            setEssentialGEStandard(essentialGEStandard)
-            setChoiceGEStandard(choiceGEStandard)
-            setLackMajor(lackMajor)
-            setLackSubMajor(lackSubMajor)
-            { localStorage.setItem('lackSubMajor', lackSubMajor) }
-            setLoadingState(true)
-        } else {
-            alert('서버와 연결이 불안정합니다. 잠시 후 다시 시도해주세요.');
+        try {
+            const response = await axios.post('https://finishline-cku.com/graduation/test_major/', {
+                student_id : localStorage.getItem('idToken')
+            });
+            if (response.data) {
+                const { major, subMajorType, doneMajor, doneSubMajor, doneMajorRest, doneSubMajorRest, doneRest, totalStandard, majorStandard, subMajorStandard, essentialGEStandard, choiceGEStandard, lackMajor, lackSubMajor } = response.data;
+                setMajor(major)
+                setSubMajorType(subMajorType)  // subMajorType / doneSubMajor / subMajorStandard
+                setDoneMajor(doneMajor)
+                setDoneSubMajor(doneSubMajor)
+                setDoneMajorRest(doneMajorRest)
+                setDoneSubMajorRest(doneSubMajorRest)
+                setDoneRest(doneRest)
+                setTotalStandard(totalStandard)
+                setMajorStandard(majorStandard)
+                setSubMajorStandard(subMajorStandard)
+                setEssentialGEStandard(essentialGEStandard)
+                setChoiceGEStandard(choiceGEStandard)
+                setLackMajor(lackMajor)
+                setLackSubMajor(lackSubMajor)
+                { localStorage.setItem('lackSubMajor', lackSubMajor) }
+                setLoadingState(true)
+                setCheckDone(prev => prev + 1)
+            } else {
+                sendEvent('graduation_test_failed', { step: 'major', reason: 'empty_response' });
+                alert('서버와 연결이 불안정합니다. 잠시 후 다시 시도해주세요.');
+            };
+        } catch (error) {
+            console.error('전공 검사 실패: ', error);
+            sendEvent('graduation_test_failed', { step: 'major', reason: 'error' });
         };
     };
 
@@ -115,60 +126,83 @@ function GraduTestPage() {
                 setLackEssentialGETopic(generalData['lackEssentialGETopic']);
                 setLackChoiceGETopic(generalData['lackChoiceGETopic']);
                 setDoneGERest(generalData['doneGERest']);
+                setCheckDone(prev => prev + 1);
             } else {
+                sendEvent('graduation_test_failed', { step: 'general', reason: 'no_user_id' });
                 console.error('user_id가 로컬스토리지에 없습니다.');
             }
         } catch (error) {
+            sendEvent('graduation_test_failed', { step: 'general', reason: 'error' });
             console.error('Error fetching data: ', error);
         }
     };
 
     const microDegreeCheck = async () => {
-        const response = await axios.post('https://finishline-cku.com/graduation/test_micro_degree/', {
-            student_id : localStorage.getItem('idToken')
-        });
-        if (response.data) {
-            const { doneMD, doneMDRest, MDStandard, restStandard, lackMD } = response.data;
-            setDoneMD(doneMD)
-            setDoneMDRest(doneMDRest)
-            setMDStandard(MDStandard)
-            setRestStandard(restStandard)
-            setLackMD(lackMD)
-        } else {
-            alert('서버와 연결이 불안정합니다. 잠시 후 다시 시도해주세요.');
+        try {
+            const response = await axios.post('https://finishline-cku.com/graduation/test_micro_degree/', {
+                student_id : localStorage.getItem('idToken')
+            });
+            if (response.data) {
+                const { doneMD, doneMDRest, MDStandard, restStandard, lackMD } = response.data;
+                setDoneMD(doneMD)
+                setDoneMDRest(doneMDRest)
+                setMDStandard(MDStandard)
+                setRestStandard(restStandard)
+                setLackMD(lackMD)
+                setCheckDone(prev => prev + 1)
+            } else {
+                sendEvent('graduation_test_failed', { step: 'micro_degree', reason: 'empty_response' });
+                alert('서버와 연결이 불안정합니다. 잠시 후 다시 시도해주세요.');
+            };
+        } catch (error) {
+            console.error('소단위전공 검사 실패: ', error);
+            sendEvent('graduation_test_failed', { step: 'micro_degree', reason: 'error' });
         };
     };
 
     const educationCheck = async () => {
-        const response = await axios.post('https://finishline-cku.com/graduation/test_education/', {
-            student_id: localStorage.getItem('idToken')
-        });
-        if (response.data) {
-            const { doneEducationRest, lackEducation } = response.data;
-            setDoneEducationRest(doneEducationRest)
-            setLackEducation(lackEducation)
-        } else {
-            alert('서버와 연결이 불안정합니다. 잠시 후 다시 시도해주세요.');
+        try {
+            const response = await axios.post('https://finishline-cku.com/graduation/test_education/', {
+                student_id: localStorage.getItem('idToken')
+            });
+            if (response.data) {
+                const { doneEducationRest, lackEducation } = response.data;
+                setDoneEducationRest(doneEducationRest)
+                setLackEducation(lackEducation)
+                setCheckDone(prev => prev + 1)
+            } else {
+                sendEvent('graduation_test_failed', { step: 'education', reason: 'empty_response' });
+                alert('서버와 연결이 불안정합니다. 잠시 후 다시 시도해주세요.');
+            };
+        } catch (error) {
+            console.error('교직 검사 실패: ', error);
+            sendEvent('graduation_test_failed', { step: 'education', reason: 'error' });
         };
     };
 
     const detailCheck = async () => {
-        const response = await axios.post('https://finishline-cku.com/graduation/ge_detail_view/', {
-            student_id: localStorage.getItem('idToken')
-        });
-        if (response.data) {
-            const { essentialTable, choiceTable, fusionTable, restTable } = response.data;
-            setEssentialGEData(essentialTable);
-            setEssentialGESuccess(essentialTable[essentialTable.length-1].success);
-            setChoiceGEData(choiceTable);
-            setChoiceGESuccess(choiceTable[choiceTable.length-1].success);
-            setFusionGEData(fusionTable);
-            setFusionGESuccess(fusionTable[fusionTable?.length-1]?.success);
-            setRestData(restTable);
-            setTrinity(essentialTable[essentialTable.length-1].trinity);
-        } else {
-            alert('서버와 연결이 불안정합니다. 잠시 후 다시 시도해주세요.');
-        }
+        try {
+            const response = await axios.post('https://finishline-cku.com/graduation/ge_detail_view/', {
+                student_id: localStorage.getItem('idToken')
+            });
+            if (response.data) {
+                const { essentialTable, choiceTable, fusionTable, restTable } = response.data;
+                setEssentialGEData(essentialTable);
+                setEssentialGESuccess(essentialTable[essentialTable.length-1].success);
+                setChoiceGEData(choiceTable);
+                setChoiceGESuccess(choiceTable[choiceTable.length-1].success);
+                setFusionGEData(fusionTable);
+                setFusionGESuccess(fusionTable[fusionTable?.length-1]?.success);
+                setRestData(restTable);
+                setTrinity(essentialTable[essentialTable.length-1].trinity);
+            } else {
+                sendEvent('graduation_test_failed', { step: 'ge_detail', reason: 'empty_response' });
+                alert('서버와 연결이 불안정합니다. 잠시 후 다시 시도해주세요.');
+            }
+        } catch (error) {
+            console.error('교양 상세 조회 실패: ', error);
+            sendEvent('graduation_test_failed', { step: 'ge_detail', reason: 'error' });
+        };
     };
 
     const goToDoneLecture = () => {
@@ -201,7 +235,13 @@ function GraduTestPage() {
         if (!loadingState) return;
         const successGraduation = (restStandard <= (doneMajorRest + doneSubMajorRest + doneGERest + doneMDRest + doneEducationRest + doneRest)) && (lackMajor + lackSubMajor + lackEssentialGE + lackChoiceGE + lackMD <= 0)
         setGraduationState(successGraduation)
-    }, [loadingState, restStandard, doneMajorRest, doneSubMajorRest, doneGERest, doneMDRest, doneEducationRest, doneRest, lackMajor, lackSubMajor, lackEssentialGE, lackChoiceGE, lackMD]);
+
+        // 4종 검사 응답이 모두 도착한 뒤에야 결과가 확정되므로, 그때 한 번만 GA에 기록한다.
+        if (checkDone >= 4 && !graduationEventSent.current) {
+            graduationEventSent.current = true;
+            sendEvent('graduation_test', { result: successGraduation ? 'possible' : 'lack' });
+        };
+    }, [loadingState, checkDone, restStandard, doneMajorRest, doneSubMajorRest, doneGERest, doneMDRest, doneEducationRest, doneRest, lackMajor, lackSubMajor, lackEssentialGE, lackChoiceGE, lackMD]);
 
     useEffect(() => {
         if (graduationState) {
@@ -477,7 +517,7 @@ function GraduTestPage() {
                                 <span className={css(styles.custom_h_focus)}>{essentialGEStandard + choiceGEStandard} 학점</span>
                             </div>
                             <div className={css(styles.detailsButtonContainer)}>
-                                <div className={css(styles.detailsButtons)} onClick={() => {detailCheck(); openDetailModal();}}>
+                                <div className={css(styles.detailsButtons)} onClick={() => {sendEvent('view_ge_detail'); detailCheck(); openDetailModal();}}>
                                     <img src={magnifyingGlass} className={css(styles.detailsButtonImage)}></img>
                                     <span className={css(styles.detailsButtonText)}>상세</span>
                                 </div>

--- a/src/pages/loginPage.jsx
+++ b/src/pages/loginPage.jsx
@@ -3,6 +3,7 @@ import { StyleSheet, css } from "aphrodite";
 import { useNavigate } from "react-router-dom";
 import { ModalContext } from '../utils/hooks/modalContext';
 import axios from 'axios';
+import { sendEvent, setUserId } from '../utils/ga';
 import Header from "../components/header";
 import Template from "../components/template";
 import Footer from "../components/footer";
@@ -30,6 +31,7 @@ function LoginPage() {
             });
 
             if (response.data.error) {
+                sendEvent('login_failed', { reason: 'rejected' });
                 alert(response.data.error);
                 return;
             }
@@ -64,11 +66,16 @@ function LoginPage() {
                 if (lackTotal) {
                     localStorage.setItem('lackTotal', lackTotal);
                 };
+                await setUserId(idToken);   // login 이벤트부터 사용자 식별이 붙도록 먼저 설정한다.
+                sendEvent('login', { method: 'student_id' });
                 navigate("/userGuidePage");
                 window.scrollTo(0, 0);
-            } 
-        } 
+            } else {
+                sendEvent('login_failed', { reason: 'no_token' });
+            }
+        }
         catch (error) {
+            sendEvent('login_failed', { reason: 'error' });
             alert("로그인에 실패했습니다. 학번과 비밀번호를 확인해주세요.");
         };
     };

--- a/src/pages/myPage.jsx
+++ b/src/pages/myPage.jsx
@@ -5,6 +5,7 @@ import { ModalContext } from '../utils/hooks/modalContext';
 import { DoneSubComponents } from '../components/doneLectureComponents';
 import { SUBMAJORTYPE } from '../pages/signupPage2';
 import axios from 'axios';
+import { clearUserId } from '../utils/ga';
 import Header from '../components/header';
 import Template from '../components/template';
 import Footer from '../components/footer';
@@ -104,6 +105,7 @@ function MyPage() {
         if (response.data) {
             if (response.data.result === true) {
                 localStorage.clear();
+                clearUserId();
                 closeModal();
                 navigate("/loginPage");
             } else {

--- a/src/pages/oneClickTestPage.jsx
+++ b/src/pages/oneClickTestPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { StyleSheet, css } from 'aphrodite';
 import { ModalContext } from '../utils/hooks/modalContext';
 import axios from 'axios';
+import { sendEvent } from '../utils/ga';
 import Lottie from "lottie-react";
 import Header from '../components/header';
 import Template from '../components/template';
@@ -44,6 +45,7 @@ function OneClickTestPage() {
                 });
                 if (response.data.success) {
                     localStorage.setItem('oneClickTest', true);
+                    sendEvent('oneclick_test', { status: 'success' });
                     navigate('/graduTestPage');
                     closeFeatModal();
                     setProcess(0);
@@ -52,11 +54,13 @@ function OneClickTestPage() {
                     const { error } = response.data;
                     closeFeatModal();
                     setProcess(0);
+                    sendEvent('oneclick_test', { status: 'fail' });
                     alert(error);
                 };
             } catch {
                 closeFeatModal();
                 setProcess(0);
+                sendEvent('oneclick_test', { status: 'error' });
                 alert("인증과정에서 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
             };
         };

--- a/src/pages/signupPage1.jsx
+++ b/src/pages/signupPage1.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { StyleSheet, css } from 'aphrodite';
 import { ModalContext } from '../utils/hooks/modalContext';
 import axios from 'axios';
+import { sendEvent } from '../utils/ga';
 import Header from '../components/header';
 import Template from '../components/template';
 import Footer from '../components/footer';
@@ -41,15 +42,18 @@ function SignupPage1() {
                 if (response.data.student_id && response.data.name && response.data.major && response.data.college) {
                     const { student_id, name, major, college } = response.data;
                     closeFeatModal();
+                    sendEvent('student_auth', { status: 'success' });
                     navigate('/signupPage2', { state: { student_id, name, major, college } });
                     window.scrollTo(0, 0);
                 } else {
                     const { error } = response.data;
                     closeFeatModal();
+                    sendEvent('student_auth', { status: 'fail' });
                     alert(error);
                 };
             } catch {
                 closeFeatModal();
+                sendEvent('student_auth', { status: 'error' });
                 alert("인증과정에서 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
             };
         };

--- a/src/pages/signupPage2.jsx
+++ b/src/pages/signupPage2.jsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { StyleSheet, css } from 'aphrodite';
 import { ModalContext } from '../utils/hooks/modalContext';
 import axios from 'axios';
+import { sendEvent, setUserId } from '../utils/ga';
 import Header from '../components/header';
 import Template from '../components/template';
 import Footer from '../components/footer';
@@ -582,6 +583,12 @@ function SignupPage2() {
                 password: password
             });
             if (response.data === true) {
+                await setUserId(student_id);
+                sendEvent('sign_up', {
+                    method: 'cku_portal',
+                    sub_major_type: additionalMajorType || 'none',
+                    micro_degree: microDegree ? 'yes' : 'no'
+                });
                 openModal();
             } else {
                 alert("회원 정보가 정상적으로 저장되지 않았습니다. 잠시 후 다시 시도해주세요.");

--- a/src/utils/ga.js
+++ b/src/utils/ga.js
@@ -29,6 +29,9 @@ function initGA() {
 function sendPageView(path, title) {
     if (!initialized) return;
     gtag('event', 'page_view', {
+        // page_path는 GA4 표준 파라미터가 아니다(UA 시절 필드).
+        // 표준 보고서의 경로는 page_location에서 도출되고, 이 값은 쿼리스트링 없는 경로를
+        // 따로 보고 싶을 때 맞춤 측정기준으로 등록해 쓰는 용도다.
         page_path: path,
         page_location: window.location.href,
         page_title: title ?? document.title,

--- a/src/utils/ga.js
+++ b/src/utils/ga.js
@@ -1,0 +1,72 @@
+// Google Analytics 4 (gtag.js) 연동
+// 측정 ID(REACT_APP_GA_MEASUREMENT_ID)가 없으면 모든 함수가 아무 동작도 하지 않는다.
+const MEASUREMENT_ID = process.env.REACT_APP_GA_MEASUREMENT_ID ?? '';
+
+let initialized = false;
+
+// gtag는 arguments 객체를 그대로 dataLayer에 넣어야 하므로 화살표 함수를 쓸 수 없다.
+function gtag() {
+    window.dataLayer.push(arguments);
+};
+
+function initGA() {
+    if (!MEASUREMENT_ID || initialized) return;
+    initialized = true;
+
+    window.dataLayer = window.dataLayer || [];
+
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${MEASUREMENT_ID}`;
+    document.head.appendChild(script);
+
+    gtag('js', new Date());
+    // SPA라 라우트가 바뀌어도 페이지가 새로 로드되지 않는다.
+    // 최초 진입까지 포함해 page_view는 usePageTracking에서 직접 보내므로 자동 전송은 끈다.
+    gtag('config', MEASUREMENT_ID, { send_page_view: false });
+};
+
+function sendPageView(path, title) {
+    if (!initialized) return;
+    gtag('event', 'page_view', {
+        page_path: path,
+        page_location: window.location.href,
+        page_title: title ?? document.title,
+    });
+};
+
+function sendEvent(name, params = {}) {
+    if (!initialized) return;
+    gtag('event', name, params);
+};
+
+// 학번은 개인정보라 GA에 원문을 보낼 수 없다.
+// 해시값만 넘겨서 같은 학생이 여러 기기에서 접속해도 한 명으로 집계되게 한다.
+const USER_ID_SALT = 'finishline-ga';
+
+async function setUserId(studentId) {
+    if (!initialized || !studentId) return;
+    // crypto.subtle은 보안 컨텍스트(HTTPS, localhost)에서만 동작한다.
+    if (!window.crypto?.subtle) return;
+
+    try {
+        const encoded = new TextEncoder().encode(`${USER_ID_SALT}:${studentId}`);
+        const digest = await window.crypto.subtle.digest('SHA-256', encoded);
+        const hashed = Array.from(new Uint8Array(digest))
+            .map(byte => byte.toString(16).padStart(2, '0'))
+            .join('')
+            .slice(0, 16);
+
+        gtag('set', { user_id: hashed });
+    } catch (error) {
+        // 사용자 식별 실패가 로그인 같은 본 기능을 막아서는 안 된다.
+        console.error('GA user_id 설정 실패: ', error);
+    };
+};
+
+function clearUserId() {
+    if (!initialized) return;
+    gtag('set', { user_id: null });
+};
+
+export { initGA, sendPageView, sendEvent, setUserId, clearUserId };

--- a/src/utils/hooks/usePageTracking.jsx
+++ b/src/utils/hooks/usePageTracking.jsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { sendPageView } from '../ga';
+
+// GA 보고서에서 경로 대신 읽기 쉬운 이름으로 보기 위한 매핑
+const PAGE_TITLES = {
+    '/': '메인',
+    '/loginPage': '로그인',
+    '/signupPage1': '회원가입 - 학생 인증',
+    '/signupPage2': '회원가입 - 추가 정보',
+    '/userGuidePage': '이용 안내',
+    '/uploadpdf': '기이수과목 PDF 등록',
+    '/donelecture': '기이수과목 관리',
+    '/oneClickTestPage': '원클릭 검사',
+    '/graduTestPage': '졸업요건 검사 결과',
+    '/manageGraduPage': '졸업요건 관리',
+    '/myPage': '마이페이지',
+};
+
+// SPA는 라우트가 바뀌어도 페이지가 새로 로드되지 않으므로 page_view를 직접 보낸다.
+function PageTracking() {
+    const location = useLocation();
+
+    useEffect(() => {
+        sendPageView(location.pathname + location.search, PAGE_TITLES[location.pathname]);
+    }, [location.pathname, location.search]);
+
+    return null;
+};
+
+export default PageTracking;

--- a/src/utils/hooks/usePageTracking.jsx
+++ b/src/utils/hooks/usePageTracking.jsx
@@ -22,7 +22,9 @@ function PageTracking() {
     const location = useLocation();
 
     useEffect(() => {
-        sendPageView(location.pathname + location.search, PAGE_TITLES[location.pathname]);
+        // 경로에는 쿼리스트링을 넣지 않는다. UTM이 붙은 랜딩이 별도 경로로 쪼개지는 것을 막기 위함이다.
+        // UTM 수집은 전체 URL을 담는 page_location이 맡으므로 영향받지 않는다.
+        sendPageView(location.pathname, PAGE_TITLES[location.pathname]);
     }, [location.pathname, location.search]);
 
     return null;


### PR DESCRIPTION
## 개요

Google Analytics 4(`G-L9V8KGLRDG`)를 연동합니다. 페이지뷰 자동 수집과 전환 이벤트 11종, 기기 간 사용자 식별을 포함합니다.

## 구조

| 파일 | 역할 |
|---|---|
| `src/utils/ga.js` | gtag.js 로더 + `initGA` / `sendPageView` / `sendEvent` / `setUserId` / `clearUserId` |
| `src/utils/hooks/usePageTracking.jsx` | 라우트 변경 감지 → `page_view` 전송, 경로별 한글 제목 매핑 |

측정 ID가 없으면 모든 함수가 no-op이라 로컬·테스트 환경에 영향이 없습니다.

`initGA()`는 `index.js`에서 렌더 **전에** 호출합니다. App의 `useEffect`에 두면 자식 effect(`PageTracking`)가 먼저 실행돼 최초 `page_view`가 `config`보다 앞서 큐에 들어가 유실됩니다.

## 수집 항목

### 페이지뷰
라우트 11개 전부에 한글 제목을 매핑했습니다. 파라미터는 `page_location`(전체 URL), `page_title`, `page_path`.

`page_path`는 GA4 표준 파라미터가 아닙니다(UA 시절 필드). 표준 보고서의 경로는 `page_location`에서 도출되며, 이 값은 **쿼리스트링 없는 경로**를 따로 보고 싶을 때 맞춤 측정기준으로 등록해 쓰는 용도입니다. UTM이 붙은 랜딩이 `/`와 `/?utm_source=...`로 쪼개지는 것을 피할 수 있습니다. UTM 수집 자체는 `page_location`이 담당하므로 영향받지 않습니다.

### 이벤트

| 이벤트 | 파라미터 |
|---|---|
| `login` | `method` |
| `login_failed` | `reason`: rejected / no_token / error |
| `student_auth` | `status`: success / fail / error |
| `sign_up` | `method`, `sub_major_type`, `micro_degree` |
| `oneclick_test` | `status`: success / fail / error |
| `upload_pdf` | `status`: success / duplicate / invalid_format / image_file / error, `file_count` |
| `search_lecture` | `search_type`, `search_term`, `status`, `result_count` |
| `save_done_lecture` | `subject_count` |
| `open_simulation` | — |
| `view_ge_detail` | — |
| `graduation_test` | `result`: possible / lack |
| `graduation_test_failed` | `step`: major / general / micro_degree / education / ge_detail, `reason` |

### 사용자 식별
학번의 SHA-256 해시 앞 16자리를 `user_id`로 전송합니다. 학번 원문은 개인정보라 보내지 않습니다. 로그인·회원가입·로그인 상태 재방문 시 설정, 로그아웃·회원탈퇴 시 해제합니다.

## 주요 판단

**`graduation_test`는 4종 검사가 모두 끝난 뒤 1회만 전송합니다.** 결과값이 전공·교양·소단위·교직 4개 API 응답을 조합해 계산되는데, 기존 effect는 값이 갱신될 때마다 재실행되고 초기 0값에서는 "졸업 가능"으로 잘못 계산됩니다. `checkDone` 카운터로 완료를 확인하고 `useRef`로 중복 전송을 막습니다.

**`testing` / `microDegreeCheck` / `educationCheck`에 try/catch를 추가했습니다.** 기존에는 예외 처리가 없어 API 실패 시 unhandled rejection으로 흘렀고, 통계에도 아무것도 남지 않았습니다. 사용자에게 보이는 동작은 바꾸지 않았습니다(alert 추가 없음, `console.error`만).

**`login`은 성공 전용으로 두고 `login_failed`를 분리했습니다.** 실패를 `login`에 합치면 GA4가 표준 전환 지표로 쓰는 로그인 수가 부풀려집니다.

## 배포 전 필수 조치

1. **GA4 관리 > 데이터 스트림 > 향상된 측정에서 "브라우저 기록 이벤트를 기반으로 하는 페이지 변경"을 끌 것.** 켜둔 채로 두면 수동 `page_view`와 중복돼 페이지뷰가 2배로 집계되고, 캠페인별 유입 수도 같이 부풀려집니다.
2. **맞춤 정의 등록.** 측정기준으로 `method`, `status`, `reason`, `step`, `result`, `search_type`, `search_term`, `sub_major_type`, `micro_degree` / 측정항목으로 `file_count`, `subject_count`, `result_count`. 쿼리스트링 없는 경로가 필요하면 `page_path`도 측정기준으로 등록하면 됩니다. 소급 적용되지 않으므로 배포 전에 등록해야 합니다.

## 알려진 한계

- **학번 해시는 완전한 익명화가 아닙니다.** 학번은 경우의 수가 수백만 개뿐이고 salt가 번들에 포함되므로 이론상 역산이 가능합니다. 백엔드가 학번과 무관한 임의 ID를 발급해 주면 그것으로 교체하는 편이 좋습니다.
- **`upload_pdf`는 한 번의 업로드에서 여러 건 발생할 수 있습니다.** 성공 파일과 중복 파일이 섞이면 2건이 전송되므로, 이벤트 수를 업로드 횟수로 해석하면 안 됩니다.
- **`search_term`은 카디널리티가 높습니다.** GA4 한도를 넘으면 일부가 `(other)`로 묶입니다.
- 광고 차단기·추적 방지로 통상 10~30% 과소 집계됩니다. 절대값보다 추세로 보셔야 합니다.

## 검증

- `CI=false yarn build` 통과, 신규 ESLint 경고 없음
- 번들에 측정 ID·gtag 로더·이벤트명 인라인 확인
- `.env`는 gitignore 대상이라 커밋에 포함되지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
